### PR TITLE
Corrected Capital letter typo

### DIFF
--- a/FloatTheadAsset.php
+++ b/FloatTheadAsset.php
@@ -16,7 +16,7 @@ use yii\web\AssetBundle;
  */
 class FloatTheadAsset extends AssetBundle
 {
-    public $sourcePath = '@bower/floatthead/dist';
+    public $sourcePath = '@bower/floatThead/dist';
     public $js = ['jquery.floatThead.min.js'];
     public $depends = [
         'yii\web\JqueryAsset',


### PR DESCRIPTION
public $sourcePath = '@bower/floatthead/dist'; to public $sourcePath = '@bower/floatThead/dist';
otherwise on unix system it's not working properly